### PR TITLE
Fixes Multipart_params to work with json/javascript

### DIFF
--- a/lib/widget/sfWidgetFormPlupload.class.php
+++ b/lib/widget/sfWidgetFormPlupload.class.php
@@ -100,7 +100,7 @@ class sfWidgetFormPlupload extends sfWidgetForm
       $pluploadOptions[] = sprintf('multipart: "%s"',$this->getOption('multipart'));
 
     if ($this->getOption('multipart_params'))
-      $pluploadOptions[] = sprintf('multipart_params: "%s"',$this->getOption('multipart_params'));
+      $pluploadOptions[] = sprintf('multipart_params: %s',$this->getOption('multipart_params'));
 
     if ($this->getOption('required_features'))
       $pluploadOptions[] = sprintf('required_features: "%s"',$this->getOption('required_features'));


### PR DESCRIPTION
Multipart_params is expected to be a json-string/object, putting it in "" does not work, same if you want to place a functioncall there which returns the needed data.

Same will probably be true for headers and some other fields, if I have time to test/use them in a real app I will create more patches.
