### PR TITLE
Make route deactivateable

### DIFF
--- a/README
+++ b/README
@@ -14,3 +14,11 @@ Installation
       .settings:
         enabled_modules:
           - sfPlupload
+
+Deactivating autoregistration of route
+--------------------------------------
+
+    # app.yml
+    all:
+    sfPluploadPlugin:
+        register_routes: false

--- a/config/app.yml
+++ b/config/app.yml
@@ -1,0 +1,3 @@
+all:
+  sfPluploadPlugin:
+    register_routes: true

--- a/config/sfPluploadPluginConfiguration.class.php
+++ b/config/sfPluploadPluginConfiguration.class.php
@@ -2,7 +2,7 @@
 
 /**
  * sfPluploadPlugin configuration.
- * 
+ *
  * @package     sfPluploadPlugin
  * @subpackage  config
  * @author      Your name here
@@ -10,21 +10,22 @@
  */
 class sfPluploadPluginConfiguration extends sfPluginConfiguration
 {
-  const VERSION = '1.0.0-DEV';
+    const VERSION = '1.0.0-DEV';
 
-  /**
-   * @see sfPluginConfiguration
-   */
-  public function initialize()
-  {
-    $this->dispatcher->connect('routing.load_configuration', array($this, 'listenToRoutingLoadConfigurationEvent'));
-  }
+    /**
+     * @see sfPluginConfiguration
+     */
+    public function initialize() {
+        if (sfConfig::get('app_sfPluploadPlugin_register_routes', true)) {
+            $this->dispatcher->connect('routing.load_configuration', array($this, 'listenToRoutingLoadConfigurationEvent'));
+        }
+    }
 
-  public function listenToRoutingLoadConfigurationEvent(sfEvent $event)
-  {
-    $r = $event->getSubject();
-    $r->prependRoute('sf_plupload_upload', new sfRoute('/sfPlupload/upload', array(
-      'module' => 'sfPlupload',
-      'action' => 'upload')));
-  }
+    public function listenToRoutingLoadConfigurationEvent(sfEvent $event) {
+        $r = $event->getSubject();
+        $r->prependRoute('sf_plupload_upload', new sfRoute('/sfPlupload/upload', array(
+                    'module' => 'sfPlupload',
+                    'action' => 'upload')));
+    }
+
 }


### PR DESCRIPTION
Since maybe not everyone wants to use/needs your controller/action, creating the route is not necessary for everybody, per default it is still activated, but everybody who wants deactivate it can do so by dding the following Code to his projects, apps or another plugins (given it is loaded after your plugin) app.yml

app.yml

```
all:
  sfPluploadPlugin:
    register_routes: false
```
